### PR TITLE
torrent: use mode 'rb' when reading torrent files

### DIFF
--- a/putio.py
+++ b/putio.py
@@ -242,7 +242,7 @@ class _Transfer(_BaseResource):
 
     @classmethod
     def add_torrent(cls, path, parent_id=0, extract=False, callback_url=None):
-        with open(path) as f:
+        with open(path, 'rb') as f:
             files = {'file': f}
             d = cls.client.request('/files/upload', method='POST', files=files,
                                    data=dict(save_parent_id=parent_id,


### PR DESCRIPTION
The default mode when calling `open` is 'r'.  This is fine on most
platforms but on Windows, files must be opened with 'rb' to avoid
problems when reading binary files (like .torrent files).

Without this change, torrent files added on Windows are frequently
truncated when being sent leading to an HTTP 400 error from the put.io
web service.

Signed-off-by: Paul Osborne <osbpau@gmail.com>