### PR TITLE
Updated for compatability with recent python versions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,8 @@ putio.py is available on PyPI.
 
 .. code-block:: bash
 
-    $ pip install putio.py
-
+    $ pip install iso8601
+    $ pip install requests
 
 Usage
 -----

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Installing
 putio.py is available on PyPI.
 
 .. code-block:: bash
-
+    $ pip install putio.py
     $ pip install iso8601
     $ pip install requests
 

--- a/putio.py
+++ b/putio.py
@@ -4,7 +4,7 @@ import re
 import json
 import logging
 import webbrowser
-from urllib import urlencode
+from urllib.parse import urlencode
 
 import requests
 import iso8601


### PR DESCRIPTION
Renamed urlencode to urlencode.parse and added dependencies from pip.