### PR TITLE
Add transfers cancel and use resume for file downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+putio.py.egg-info/

--- a/putio.py
+++ b/putio.py
@@ -69,8 +69,12 @@ class Client(object):
         self.access_token = access_token
         self.session = requests.session()
 
-        # Retry maximum 10 times, backoff on each retry, sleeping 1s, 2s, 4s, 8s, to a maximum of 120s
-        retries = Retry(total=10, backoff_factor=1)
+        # Retry maximum 10 times, backoff on each retry
+        # Sleeps 1s, 2s, 4s, 8s, etc to a maximum of 120s between retries
+        # Retries on HTTP status codes 500, 502, 503, 504
+        retries = Retry(total=10,
+                        backoff_factor=1,
+                        status_forcelist=[ 500, 502, 503, 504 ])
 
         # Use the retry strategy for all HTTPS requests
         self.session.mount('https://', HTTPAdapter(max_retries=retries))

--- a/putio.py
+++ b/putio.py
@@ -9,6 +9,15 @@ from urllib import urlencode
 import requests
 import iso8601
 
+KB = 1024
+MB = 1024 * KB
+
+# Downloads are broken up into ranges of this size
+RANGE_SIZE = 10 * MB
+
+# Downloads are written and flushed after a chunk of this size
+CHUNK_SIZE = 8 * KB
+
 BASE_URL = 'https://api.put.io/v2'
 ACCESS_TOKEN_URL = 'https://api.put.io/v2/oauth2/access_token'
 AUTHENTICATION_URL = 'https://api.put.io/v2/oauth2/authenticate'
@@ -165,11 +174,11 @@ class _File(_BaseResource):
         """List the files under directory."""
         return self.list(parent_id=self.id)
 
-    def download(self, dest='.', delete_after_download=False):
+    def download(self, dest='.', delete_after_download=False, range_size=RANGE_SIZE, chunk_size=CHUNK_SIZE):
         if self.content_type == 'application/x-directory':
             self._download_directory(dest, delete_after_download)
         else:
-            self._download_file(dest, delete_after_download)
+            self._download_file(dest, delete_after_download, range_size, chunk_size)
 
     def _download_directory(self, dest='.', delete_after_download=False):
         name = self.name
@@ -186,24 +195,40 @@ class _File(_BaseResource):
         if delete_after_download:
             self.delete()
 
-    def _download_file(self, dest='.', delete_after_download=False):
-        response = self.client.request(
-            '/files/%s/download' % self.id, raw=True, stream=True)
+    def _download_file(self, dest='.', delete_after_download=False, range_size=RANGE_SIZE, chunk_size=CHUNK_SIZE):
+        filename = self.name.strip('"')
+        filepath = os.path.join(dest, filename)
 
-        filename = re.match(
-            'attachment; filename=(.*)',
-            response.headers['content-disposition']).groups()[0]
-        # If file name has spaces, it must have quotes around.
-        filename = filename.strip('"')
+        if os.path.exists(filepath):
+            first_byte = os.path.getsize(filepath)
+        else:
+            first_byte = 0
 
-        with open(os.path.join(dest, filename), 'wb') as f:
-            for chunk in response.iter_content(chunk_size=1024):
-                if chunk:  # filter out keep-alive new chunks
-                    f.write(chunk)
-                    f.flush()
+        logging.debug('file %s is currently %d, should be %d' % (filepath, first_byte, self.size))
 
-        if delete_after_download:
-            self.delete()
+        with open(filepath, 'ab') as f:
+            # Split up file into blocks of RANGE_SIZE each
+            while first_byte < self.size:
+                if first_byte + range_size < self.size:
+                    last_byte = first_byte + range_size
+                else:
+                    last_byte = self.size
+
+                logging.debug('download range %d - %d' % (first_byte, last_byte))
+
+                headers = { 'Range': 'bytes=%d-%d' % (first_byte, last_byte) }
+                response = self.client.request('/files/%s/download' % self.id, headers=headers, raw=True, stream=True)
+
+                for chunk in response.iter_content(chunk_size=chunk_size):
+                    if chunk:  # filter out keep-alive new chunks
+                        f.write(chunk)
+                        f.flush()
+
+                first_byte = last_byte + 1
+    
+        if self.size == os.path.getsize(filepath):
+            if delete_after_download:
+                self.delete()
 
     def delete(self):
         return self.client.request('/files/delete', method='POST',

--- a/putio.py
+++ b/putio.py
@@ -209,7 +209,7 @@ class _File(_BaseResource):
             # Split up file into blocks of RANGE_SIZE each
             while first_byte < self.size:
                 if first_byte + range_size < self.size:
-                    last_byte = first_byte + range_size
+                    last_byte = min(first_byte + range_size, self.size)
                 else:
                     last_byte = self.size
 

--- a/putio.py
+++ b/putio.py
@@ -196,8 +196,7 @@ class _File(_BaseResource):
             self.delete()
 
     def _download_file(self, dest='.', delete_after_download=False, range_size=RANGE_SIZE, chunk_size=CHUNK_SIZE):
-        filename = self.name.strip('"')
-        filepath = os.path.join(dest, filename)
+        filepath = os.path.join(dest, self.name)
 
         if os.path.exists(filepath):
             first_byte = os.path.getsize(filepath)

--- a/putio.py
+++ b/putio.py
@@ -6,7 +6,7 @@ import logging
 import webbrowser
 
 from urllib import urlencode
-from urllib3.util.retry import Retry
+from requests.packages.urllib3.util.retry import Retry
 
 import requests
 from requests.adapters import HTTPAdapter

--- a/putio.py
+++ b/putio.py
@@ -255,6 +255,11 @@ class _Transfer(_BaseResource):
     def clean(cls):
         return cls.client.request('/transfers/clean', method='POST')
 
+    @classmethod
+    def cancel(cls, transfer_ids):
+        return cls.client.request('/transfers/cancel', method='POST',
+                                   data={'transfer_ids': ','.join(transfer_ids)})
+
 
 class _Account(_BaseResource):
 

--- a/putio.py
+++ b/putio.py
@@ -27,15 +27,6 @@ AUTHENTICATION_URL = 'https://api.put.io/v2/oauth2/authenticate'
 
 logger = logging.getLogger(__name__)
 
-# Use a more complex retry strategy
-s = requests.Session()
-
-# Retry maximum 10 times, backoff on each retry, sleeping 1s, 2s, 4s, 8s, to a maximum of 120s
-retries = Retry(total=10, backoff_factor=1)
-
-# Use the retry strategy for all HTTPS requests
-s.mount('https://', HTTPAdapter(max_retries=retries))
-
 
 class AuthHelper(object):
 
@@ -77,6 +68,12 @@ class Client(object):
     def __init__(self, access_token):
         self.access_token = access_token
         self.session = requests.session()
+
+        # Retry maximum 10 times, backoff on each retry, sleeping 1s, 2s, 4s, 8s, to a maximum of 120s
+        retries = Retry(total=10, backoff_factor=1)
+
+        # Use the retry strategy for all HTTPS requests
+        self.session.mount('https://', HTTPAdapter(max_retries=retries))
 
         # Keep resource classes as attributes of client.
         # Pass client to resource classes so resource object

--- a/putio.py
+++ b/putio.py
@@ -254,7 +254,6 @@ class _File(_BaseResource):
                 for chunk in response.iter_content(chunk_size=chunk_size):
                     if chunk:  # filter out keep-alive new chunks
                         f.write(chunk)
-                        f.flush()
     
         if self._verify_file(filepath, chunk_size):
             if delete_after_download:

--- a/putio.py
+++ b/putio.py
@@ -311,8 +311,10 @@ class _Transfer(_BaseResource):
 
     @classmethod
     def cancel(cls, transfer_ids):
-        return cls.client.request('/transfers/cancel', method='POST',
-                                   data={'transfer_ids': ','.join(transfer_ids)})
+        transfer_ids = ','.join([ str(transfer_id) for transfer_id in transfer_ids ])
+        return cls.client.request('/transfers/cancel',
+                                  method='POST',
+                                  data={'transfer_ids': transfer_ids})
 
 
 class _Account(_BaseResource):

--- a/putio.py
+++ b/putio.py
@@ -4,9 +4,13 @@ import re
 import json
 import logging
 import webbrowser
+
 from urllib import urlencode
+from urllib3.util.retry import Retry
 
 import requests
+from requests.adapters import HTTPAdapter
+
 import iso8601
 import binascii
 
@@ -22,6 +26,15 @@ ACCESS_TOKEN_URL = 'https://api.put.io/v2/oauth2/access_token'
 AUTHENTICATION_URL = 'https://api.put.io/v2/oauth2/authenticate'
 
 logger = logging.getLogger(__name__)
+
+# Use a more complex retry strategy
+s = requests.Session()
+
+# Retry maximum 10 times, backoff on each retry, sleeping 1s, 2s, 4s, 8s, to a maximum of 120s
+retries = Retry(total=10, backoff_factor=1)
+
+# Use the retry strategy for all HTTPS requests
+s.mount('https://', HTTPAdapter(max_retries=retries))
 
 
 class AuthHelper(object):

--- a/putio.py
+++ b/putio.py
@@ -208,10 +208,7 @@ class _File(_BaseResource):
         with open(filepath, 'ab') as f:
             # Split up file into blocks of RANGE_SIZE each
             while first_byte < self.size:
-                if first_byte + range_size < self.size:
-                    last_byte = min(first_byte + range_size, self.size)
-                else:
-                    last_byte = self.size
+                last_byte = min(first_byte + range_size, self.size) - 1
 
                 logging.debug('download range %d - %d' % (first_byte, last_byte))
 

--- a/putio.py
+++ b/putio.py
@@ -221,7 +221,8 @@ class _File(_BaseResource):
                 for chunk in response.iter_content(chunk_size=chunk_size):
                     if chunk:  # filter out keep-alive new chunks
                         f.write(chunk)
-                        f.flush()
+
+                f.flush()
 
                 first_byte = last_byte + 1
     

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     include_package_data=True,
     zip_safe=True,
     platforms='any',
-    install_requires=['requests', 'iso8601'],
+    install_requires=['requests', 'iso8601', 'urllib3'],
 )

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     include_package_data=True,
     zip_safe=True,
     platforms='any',
-    install_requires=['requests', 'iso8601', 'urllib3'],
+    install_requires=['requests', 'iso8601'],
 )


### PR DESCRIPTION
File downloads now use ranged, chunked transfers. If a download fails partway through, the next time download method is called, it will resume from where it left off. The remote file is only deleted if the local file size matches the remote file size.

Downloads are flushed in broad ranges of 10MB by default, and each range is written in chunks of 8KB. Alter these depending on your network speed and reliability.

Both sizes are added as parameters to the download method.

I also added a transfers cancel API call, it was missing.