### PR TITLE
Transfers cancel method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+putio.py.egg-info/

--- a/putio.py
+++ b/putio.py
@@ -255,6 +255,13 @@ class _Transfer(_BaseResource):
     def clean(cls):
         return cls.client.request('/transfers/clean', method='POST')
 
+    @classmethod
+    def cancel(cls, transfer_ids):
+        transfer_ids = ','.join([ str(transfer_id) for transfer_id in transfer_ids ])
+        return cls.client.request('/transfers/cancel',
+                                  method='POST',
+                                  data={'transfer_ids': transfer_ids})
+
 
 class _Account(_BaseResource):
 


### PR DESCRIPTION
Add transfers cancel method, mirroring the web site usage
Add gitignore for build files
Transfer IDs are converted to strings to be joined