### PR TITLE
Use non-deprecated API for download()

### DIFF
--- a/putiopy.py
+++ b/putiopy.py
@@ -445,7 +445,9 @@ class _File(_BaseResource):
                     headers = {'Range': 'bytes=%d-' % first_byte}
 
                     logger.debug('request range: bytes=%d-' % first_byte)
-                    response = self.client.request('/files/%s/download' % self.id,
+                    path = '/files/%d/url' % self.id
+                    download_link = self._get_link(path)
+                    response = self.client.request(download_link,
                                                    headers=headers,
                                                    raw=True,
                                                    stream=True)


### PR DESCRIPTION
Don't use deprecated `/files/{id}/download` API method, use `/files/{id}/url` method instead